### PR TITLE
Add missing resource marks before parsing descriptors

### DIFF
--- a/src/hotspot/cpu/aarch64/universalNativeInvoker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalNativeInvoker_aarch64.cpp
@@ -150,6 +150,7 @@ public:
 };
 
 jlong ProgrammableInvoker::generate_adapter(jobject jabi, jobject jlayout) {
+  ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parseABIDescriptor(jabi);
   const BufferLayout layout = ForeignGlobals::parseBufferLayout(jlayout);
 

--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -185,6 +185,7 @@ static address generate_upcall_stub(jobject rec, const ABIDescriptor& abi,
 }
 
 jlong ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jabi, jobject jlayout) {
+  ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parseABIDescriptor(jabi);
   const BufferLayout layout = ForeignGlobals::parseBufferLayout(jlayout);
 

--- a/src/hotspot/cpu/x86/universalNativeInvoker_x86.cpp
+++ b/src/hotspot/cpu/x86/universalNativeInvoker_x86.cpp
@@ -188,6 +188,7 @@ public:
 };
 
 jlong ProgrammableInvoker::generate_adapter(jobject jabi, jobject jlayout) {
+  ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parseABIDescriptor(jabi);
   const BufferLayout layout = ForeignGlobals::parseBufferLayout(jlayout);
 

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86.cpp
@@ -237,6 +237,7 @@ static address generate_upcall_stub(jobject rec, const ABIDescriptor& abi, const
 }
 
 jlong ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jabi, jobject jlayout) {
+  ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parseABIDescriptor(jabi);
   const BufferLayout layout = ForeignGlobals::parseBufferLayout(jlayout);
 


### PR DESCRIPTION
Adds missing resource marks before parsing descriptors. (problem showed up an separate experiments)