### PR TITLE
Address review comments

### DIFF
--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -24,102 +24,14 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
-#include "classfile/javaClasses.inline.hpp"
-#include "classfile/symbolTable.hpp"
-#include "include/jvm.h"
-#include "jni.h"
-#include "logging/log.hpp"
-#include "logging/logStream.hpp"
-#include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
-#include "oops/arrayOop.inline.hpp"
 #include "prims/universalUpcallHandler.hpp"
-#include "runtime/interfaceSupport.inline.hpp"
-#include "runtime/javaCalls.hpp"
-#include "runtime/jniHandles.inline.hpp"
 
-static constexpr CodeBuffer::csize_t upcall_stub_size = 1024;
-
-extern struct JavaVM_ main_vm;
-
-static struct {
-  bool inited;
-  struct {
-    Klass* klass;
-    Symbol* name;
-    Symbol* sig;
-  } upcall_method;  // jdk.internal.foreign.abi.UniversalUpcallHandler::invoke
-} upcall_info;
-
-// FIXME: This should be initialized explicitly instead of lazily/racily
-static void upcall_init() {
-#if 0
-  fprintf(stderr, "upcall_init()\n");
-#endif
-
-  TRAPS = Thread::current();
-  ResourceMark rm;
-
-  const char* cname = "jdk/internal/foreign/abi/ProgrammableUpcallHandler";
-  const char* mname = "invoke";
-  const char* mdesc = "(Ljdk/internal/foreign/abi/ProgrammableUpcallHandler;J)V";
-  Symbol* cname_sym = SymbolTable::new_symbol(cname, (int)strlen(cname));
-  Symbol* mname_sym = SymbolTable::new_symbol(mname, (int)strlen(mname));
-  Symbol* mdesc_sym = SymbolTable::new_symbol(mdesc, (int)strlen(mdesc));
-
-#if 0
-  ::fprintf(stderr, "cname_sym: %p\n", cname_sym);
-  ::fprintf(stderr, "mname_sym: %p\n", mname_sym);
-  ::fprintf(stderr, "mdesc_sym: %p\n", mdesc_sym);
-#endif
-
-  Klass* k = SystemDictionary::resolve_or_null(cname_sym, THREAD);
-#if 0
-  ::fprintf(stderr, "Klass: %p\n", k);
-#endif
-
-  Method* method = k->lookup_method(mname_sym, mdesc_sym);
-#if 0
-  ::fprintf(stderr, "Method: %p\n", method);
-#endif
-
-  upcall_info.upcall_method.klass = k;
-  upcall_info.upcall_method.name = mname_sym;
-  upcall_info.upcall_method.sig = mdesc_sym;
-
-  upcall_info.inited = true;
-}
-
-static void upcall_helper(jobject rec, address buff) {
-  void *p_env = NULL;
-
-  Thread* thread = Thread::current_or_null();
-  if (thread == NULL) {
-    JavaVM_ *vm = (JavaVM *)(&main_vm);
-    vm -> functions -> AttachCurrentThreadAsDaemon(vm, &p_env, NULL);
-    thread = Thread::current();
-  }
-
-  assert(thread->is_Java_thread(), "really?");
-
-  ThreadInVMfromNative __tiv((JavaThread *)thread);
-
-  if (!upcall_info.inited) {
-    upcall_init();
-  }
-
-  ResourceMark rm;
-  JavaValue result(T_VOID);
-  JavaCallArguments args(2); // long = 2 slots
-
-  args.push_jobject(rec);
-  args.push_long((jlong) buff);
-
-  JavaCalls::call_static(&result, upcall_info.upcall_method.klass,
-                         upcall_info.upcall_method.name, upcall_info.upcall_method.sig,
-                         &args, thread);
-}
-
+// 1. Create buffer according to layout
+// 2. Load registers & stack args into buffer
+// 3. Call upcall helper with upcall handler instance & buffer pointer (C++ ABI)
+// 4. Load return value from buffer into foreign ABI registers
+// 5. Return
 address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jabi, jobject jlayout) {
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
@@ -162,7 +74,7 @@ address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jab
   // Call upcall helper
   __ ldr(c_rarg0, rec_adr);
   __ mov(c_rarg1, sp);
-  __ movptr(rscratch1, CAST_FROM_FN_PTR(uint64_t, upcall_helper));
+  __ movptr(rscratch1, CAST_FROM_FN_PTR(uint64_t, ProgrammableUpcallHandler::attach_thread_and_do_upcall));
   __ blr(rscratch1);
 
   for (int i = 0; i < abi._integer_return_registers.length(); i++) {

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86.cpp
@@ -23,102 +23,14 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
-#include "classfile/javaClasses.inline.hpp"
-#include "interpreter/interpreter.hpp"
-#include "interpreter/interpreterRuntime.hpp"
-#include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
-#include "include/jvm.h"
-#include "jni.h"
 #include "prims/universalUpcallHandler.hpp"
-#include "runtime/javaCalls.hpp"
-#include "runtime/interfaceSupport.inline.hpp"
-#include "logging/log.hpp"
-#include "logging/logStream.hpp"
-#include "oops/arrayOop.inline.hpp"
-#include "runtime/jniHandles.inline.hpp"
-#include "classfile/symbolTable.hpp"
 
-static constexpr CodeBuffer::csize_t upcall_stub_size = 1024;
-
-extern struct JavaVM_ main_vm;
-
-static struct {
-  bool inited;
-  struct {
-    Klass* klass;
-    Symbol* name;
-    Symbol* sig;
-  } upcall_method;  // jdk.internal.foreign.abi.UniversalUpcallHandler::invoke
-} upcall_info;
-
-// FIXME: This should be initialized explicitly instead of lazily/racily
-static void upcall_init() {
-#if 0
-  fprintf(stderr, "upcall_init()\n");
-#endif
-
-  TRAPS = Thread::current();
-  ResourceMark rm;
-
-  const char* cname = "jdk/internal/foreign/abi/ProgrammableUpcallHandler";
-  const char* mname = "invoke";
-  const char* mdesc = "(Ljdk/internal/foreign/abi/ProgrammableUpcallHandler;J)V";
-  Symbol* cname_sym = SymbolTable::new_symbol(cname, (int)strlen(cname));
-  Symbol* mname_sym = SymbolTable::new_symbol(mname, (int)strlen(mname));
-  Symbol* mdesc_sym = SymbolTable::new_symbol(mdesc, (int)strlen(mdesc));
-
-#if 0
-  ::fprintf(stderr, "cname_sym: %p\n", cname_sym);
-  ::fprintf(stderr, "mname_sym: %p\n", mname_sym);
-  ::fprintf(stderr, "mdesc_sym: %p\n", mdesc_sym);
-#endif
-
-  Klass* k = SystemDictionary::resolve_or_null(cname_sym, THREAD);
-#if 0
-  ::fprintf(stderr, "Klass: %p\n", k);
-#endif
-
-  Method* method = k->lookup_method(mname_sym, mdesc_sym);
-#if 0
-  ::fprintf(stderr, "Method: %p\n", method);
-#endif
-
-  upcall_info.upcall_method.klass = k;
-  upcall_info.upcall_method.name = mname_sym;
-  upcall_info.upcall_method.sig = mdesc_sym;
-
-  upcall_info.inited = true;
-}
-
-static void upcall_helper(jobject rec, address buff) {
-  void *p_env = NULL;
-
-  Thread* thread = Thread::current_or_null();
-  if (thread == NULL) {
-    JavaVM_ *vm = (JavaVM *)(&main_vm);
-    vm -> functions -> AttachCurrentThreadAsDaemon(vm, &p_env, NULL);
-    thread = Thread::current();
-  }
-
-  assert(thread->is_Java_thread(), "really?");
-
-  ThreadInVMfromNative __tiv((JavaThread *)thread);
-
-  if (!upcall_info.inited) {
-    upcall_init();
-  }
-
-  ResourceMark rm;
-  JavaValue result(T_VOID);
-  JavaCallArguments args(2); // long = 2 slots
-
-  args.push_jobject(rec);
-  args.push_long((jlong) buff);
-
-  JavaCalls::call_static(&result, upcall_info.upcall_method.klass, upcall_info.upcall_method.name, upcall_info.upcall_method.sig, &args, thread);
-}
-
+// 1. Create buffer according to layout
+// 2. Load registers & stack args into buffer
+// 3. Call upcall helper with upcall handler instance & buffer pointer (C++ ABI)
+// 4. Load return value from buffer into foreign ABI registers
+// 5. Return
 address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jabi, jobject jlayout) {
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
@@ -195,7 +107,7 @@ address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jab
   __ subptr(rsp, 32);
 #endif
 
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, upcall_helper)));
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::attach_thread_and_do_upcall)));
 
 #ifdef _WIN64
   __ block_comment("pop shadow space");

--- a/src/hotspot/share/prims/universalNativeInvoker.cpp
+++ b/src/hotspot/share/prims/universalNativeInvoker.cpp
@@ -22,14 +22,15 @@
  */
 
 #include "precompiled.hpp"
-#include "code/codeBlob.hpp"
 #include "prims/universalNativeInvoker.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
-#include "runtime/jniHandles.inline.hpp"
-#include "runtime/stubCodeGenerator.hpp"
-#include "prims/methodHandles.hpp"
 
-void ProgrammableInvoker::invoke_native(ProgrammableStub stub, address buff, JavaThread* thread) {
+ProgrammableInvoker::Generator::Generator(CodeBuffer* code, const ABIDescriptor* abi, const BufferLayout* layout)
+  : StubCodeGenerator(code),
+    _abi(abi),
+    _layout(layout) {}
+
+void ProgrammableInvoker::invoke_native(Stub stub, address buff, JavaThread* thread) {
   {
     assert(thread->thread_state() == _thread_in_vm, "thread state is: %d", thread->thread_state());
     ThreadToNativeFromVM ttnfvm(thread);
@@ -42,13 +43,13 @@ void ProgrammableInvoker::invoke_native(ProgrammableStub stub, address buff, Jav
 
 JNI_ENTRY(void, PI_invokeNative(JNIEnv* env, jclass _unused, jlong adapter_stub, jlong buff))
   assert(thread->thread_state() == _thread_in_vm, "thread state is: %d", thread->thread_state());
-  ProgrammableStub stub = (ProgrammableStub) adapter_stub;
+  ProgrammableInvoker::Stub stub = (ProgrammableInvoker::Stub) adapter_stub;
   address c = (address) buff;
   ProgrammableInvoker::invoke_native(stub, c, thread);
 JNI_END
 
 JNI_ENTRY(jlong, PI_generateAdapter(JNIEnv* env, jclass _unused, jobject abi, jobject layout))
-  return ProgrammableInvoker::generate_adapter(abi, layout);
+  return (jlong) ProgrammableInvoker::generate_adapter(abi, layout);
 JNI_END
 
 #define CC (char*)  /*cast a literal from (const char*)*/

--- a/src/hotspot/share/prims/universalNativeInvoker.hpp
+++ b/src/hotspot/share/prims/universalNativeInvoker.hpp
@@ -24,28 +24,27 @@
 #ifndef SHARE_VM_PRIMS_UNIVERSALNATIVEINVOKER_HPP
 #define SHARE_VM_PRIMS_UNIVERSALNATIVEINVOKER_HPP
 
-#include "classfile/javaClasses.hpp"
-#include "classfile/vmSymbols.hpp"
-#include "include/jvm.h"
-#include "runtime/frame.inline.hpp"
-#include "runtime/globals.hpp"
-#include "utilities/macros.hpp"
+#include "runtime/stubCodeGenerator.hpp"
 #include "prims/foreign_globals.hpp"
 
-#ifdef ZERO
-# include "entry_zero.hpp"
-#endif
-
-class MacroAssembler;
-class Label;
-class ShuffleRecipe;
-
-typedef void (*ProgrammableStub)(address);
-
 class ProgrammableInvoker: AllStatic {
+private:
+  static constexpr CodeBuffer::csize_t native_invoker_size = 1024;
+
+  class Generator : StubCodeGenerator {
+  private:
+    const ABIDescriptor* _abi;
+    const BufferLayout* _layout;
+  public:
+    Generator(CodeBuffer* code, const ABIDescriptor* abi, const BufferLayout* layout);
+
+    void generate();
+  };
 public:
-  static void invoke_native(ProgrammableStub stub, address buff, JavaThread* thread);
-  static jlong generate_adapter(jobject abi, jobject layout);
+  using Stub = void(*)(address);
+
+  static void invoke_native(Stub stub, address buff, JavaThread* thread);
+  static address generate_adapter(jobject abi, jobject layout);
 };
 
 #endif // SHARE_VM_PRIMS_UNIVERSALNATIVEINVOKER_HPP

--- a/src/hotspot/share/prims/universalUpcallHandler.hpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.hpp
@@ -24,15 +24,24 @@
 #ifndef SHARE_VM_PRIMS_UNIVERSALUPCALLHANDLER_HPP
 #define SHARE_VM_PRIMS_UNIVERSALUPCALLHANDLER_HPP
 
-#include "classfile/javaClasses.hpp"
-#include "classfile/vmSymbols.hpp"
-#include "include/jvm.h"
-#include "runtime/frame.inline.hpp"
-#include "runtime/globals.hpp"
-#include "utilities/macros.hpp"
 #include "prims/foreign_globals.hpp"
 
-class ProgrammableUpcallHandler : AllStatic {
+class ProgrammableUpcallHandler {
+private:
+  static constexpr CodeBuffer::csize_t upcall_stub_size = 1024;
+
+  struct UpcallMethod {
+    Klass* klass;
+    Symbol* name;
+    Symbol* sig;
+  } upcall_method;
+
+  ProgrammableUpcallHandler();
+
+  static const ProgrammableUpcallHandler& instance();
+
+  static void upcall_helper(JNIEnv* env, jobject rec, address buff);
+  static void attach_thread_and_do_upcall(jobject rec, address buff);
 public:
   static address generate_upcall_stub(jobject rec, jobject abi, jobject buffer_layout);
 };


### PR DESCRIPTION
- Merge both versions of upcall_init and move the code to (the constructor of) ProgrammableUpcallHandler. Using the same lazy singleton pattern as for ForeignGlobals to make initialization thread-safe.
- Merge both PorgrammableInvokeGenerator classes into a shared ProgrammableInvoke::Generator class.
- Also move ProgrammableStub to ProgrammableInvoke::Stub for better name-spacing
- Also move native_invoker_size constant to ProgrammableInvoker (we now have 1 instead of 2)
- Merge ProgrammableInvoker::Generator::generate and top-level generate_invoke_native functions (avoiding the need to forward fields)
- Split upcall_helper method into ProgrammableUpcallHandler::attach_thread_and_do_upcall and upcall_helper. The former does the thread attach/detach, the latter does the actual upcall.
- Add a few comments to ProgrammableUpcallHandler::generate_upcall_stub
- Remove unused imports