### PR TITLE
Add MXCSR save and restore to upcall stubs for non-windows platforms

### DIFF
--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -32,6 +32,7 @@
 #include "prims/universalUpcallHandler.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/signature.hpp"
+#include "runtime/stubRoutines.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -418,6 +419,11 @@ static int compute_reg_save_area_size(const ABIDescriptor& abi) {
     }
   }
 
+#ifndef _WIN64
+  // for mxcsr
+  size += 8;
+#endif
+
   return size;
 }
 
@@ -436,11 +442,13 @@ static int compute_arg_save_area_size(const CallRegs& conv) {
   return result_size;
 }
 
+constexpr int MXCSR_MASK = 0xFFC0;  // Mask out any pending exceptions
+
 static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
   // 1. iterate all registers in the architecture
   //     - check if they are volatile or not for the given abi
   //     - if NOT, we need to save it here
-  // 2. save mxcsr (?)
+  // 2. save mxcsr on non-windows platforms
 
   int offset = reg_save_area_offset;
 
@@ -467,16 +475,30 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
       }
     }
   }
-  __ block_comment("} preserve_callee_saved_regs ");
 
-  // TODO mxcsr
+#ifndef _WIN64
+  {
+    const Address mxcsr_save(rsp, offset);
+    Label skip_ldmx;
+    __ stmxcsr(mxcsr_save);
+    __ movl(rax, mxcsr_save);
+    __ andl(rax, MXCSR_MASK);    // Only check control and mask bits
+    ExternalAddress mxcsr_std(StubRoutines::addr_mxcsr_std());
+    __ cmp32(rax, mxcsr_std);
+    __ jcc(Assembler::equal, skip_ldmx);
+    __ ldmxcsr(mxcsr_std);
+    __ bind(skip_ldmx);
+  }
+#endif
+
+  __ block_comment("} preserve_callee_saved_regs ");
 }
 
 static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
   // 1. iterate all registers in the architecture
   //     - check if they are volatile or not for the given abi
   //     - if NOT, we need to restore it here
-  // 2. restore mxcsr (?)
+  // 2. restore mxcsr on non-windows platforms
 
   int offset = reg_save_area_offset;
 
@@ -504,9 +526,12 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
     }
   }
 
-  __ block_comment("} restore_callee_saved_regs ");
+#ifndef _WIN64
+  const Address mxcsr_save(rsp, offset);
+  __ ldmxcsr(mxcsr_save);
+#endif
 
-  // TODO mxcsr
+  __ block_comment("} restore_callee_saved_regs ");
 }
 
 static void shuffle_arguments(MacroAssembler* _masm, const GrowableArray<ArgMove>& arg_moves) {


### PR DESCRIPTION
Add MXCSR control register save and restore to optimized upcall stubs, copied from the equivalent JNI call in generate_call_stub: https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp#L286-L297

(to be on the safe side)

Testing: running java/foreign tests on Linux