### PR TITLE
Add @apiNote to package-info

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -215,6 +215,9 @@
  * type must not be null, and any null argument will elicit a {@code NullPointerException}.  This fact is not individually
  * documented for methods of this API.
  *
+ * @apiNote Usual memory model guarantees, for example stated in {@jls 6.6} and {@jls 10.4}, do not apply
+ * when accessing native memory segments as these segments are backed by off-heap regions of memory.
+ *
  * @implNote
  * In the reference implementation, access to restricted methods can be granted to specific modules using the command line option
  * {@code --enable-native-access=M1,M2, ... Mn}, where {@code M1}, {@code M2}, {@code ... Mn} are module names


### PR DESCRIPTION
This PR proposes an `@apiNote` regarding memory guarantees