### PR TITLE
Implementation: Add a decoupled SessionFactory

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -26,6 +26,7 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.SessionFactory;
 import jdk.internal.javac.PreviewFeature;
 
 import java.util.Objects;
@@ -135,7 +136,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * @return a new confined arena.
      */
     static Arena openConfined() {
-        return makeArena(MemorySessionImpl.createConfined(Thread.currentThread()));
+        return makeArena(SessionFactory.createConfined(Thread.currentThread()));
     }
 
     /**
@@ -143,7 +144,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * @return a new shared arena.
      */
     static Arena openShared() {
-        return makeArena(MemorySessionImpl.createShared());
+        return makeArena(SessionFactory.createShared());
     }
 
     private static Arena makeArena(MemorySessionImpl sessionImpl) {

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -26,6 +26,7 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.SessionFactory;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.ref.CleanerFactory;
 
@@ -108,7 +109,7 @@ public sealed interface MemorySession permits MemorySessionImpl {
      * @return a new bounded memory session that is managed, implicitly, by the garbage collector.
      */
     static MemorySession implicit() {
-        return MemorySessionImpl.createImplicit(CleanerFactory.cleaner());
+        return SessionFactory.createImplicit(CleanerFactory.cleaner());
     }
 
     /**
@@ -118,6 +119,6 @@ public sealed interface MemorySession permits MemorySessionImpl {
      * @return an unbounded memory session.
      */
     static MemorySession global() {
-        return MemorySessionImpl.GLOBAL;
+        return SessionFactory.global();
     }
 }

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -28,6 +28,7 @@ package java.lang.foreign;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.SessionFactory;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.NativeLibrary;
@@ -160,7 +161,7 @@ public interface SymbolLookup {
                 ClassLoader.getSystemClassLoader();
         MemorySession loaderSession = (loader == null || loader instanceof BuiltinClassLoader) ?
                 MemorySession.global() : // builtin loaders never go away
-                MemorySessionImpl.heapSession(loader);
+                SessionFactory.createHeap(loader);
         return name -> {
             Objects.requireNonNull(name);
             JavaLangAccess javaLangAccess = SharedSecrets.getJavaLangAccess();

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -479,7 +479,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         if (bufferSegment != null) {
             bufferSession = bufferSegment.session;
         } else {
-            bufferSession = MemorySessionImpl.heapSession(bb);
+            bufferSession = SessionFactory.createHeap(bb);
         }
         boolean readOnly = bb.isReadOnly();
         int scaleFactor = getScaleFactor(bb);

--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
@@ -51,7 +51,7 @@ final class ConfinedSession extends MemorySessionImpl {
         }
     }
 
-    public ConfinedSession(Thread owner) {
+    ConfinedSession(Thread owner) {
         super(owner, new ConfinedResourceList());
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
@@ -36,7 +36,7 @@ final class GlobalSession extends MemorySessionImpl {
 
     final Object ref;
 
-    public GlobalSession(Object ref) {
+    GlobalSession(Object ref) {
         super(null, null);
         this.ref = ref;
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/ImplicitSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ImplicitSession.java
@@ -40,7 +40,7 @@ import java.lang.ref.Reference;
  */
 final class ImplicitSession extends SharedSession {
 
-    public ImplicitSession(Cleaner cleaner) {
+    ImplicitSession(Cleaner cleaner) {
         super();
         cleaner.register(this, resourceList);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -51,7 +51,7 @@ public sealed class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     @Override
     ByteBuffer makeByteBuffer() {
         return NIO_ACCESS.newMappedByteBuffer(unmapper, min, (int)length, null,
-                session == MemorySessionImpl.GLOBAL ? null : this);
+                session == SessionFactory.global() ? null : this);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -59,8 +59,6 @@ public abstract sealed class MemorySessionImpl
     static final VarHandle STATE;
     static final int MAX_FORKS = Integer.MAX_VALUE;
 
-    public static final MemorySessionImpl GLOBAL = new GlobalSession(null);
-
     static final ScopedMemoryAccess.ScopedAccessError ALREADY_CLOSED = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::alreadyClosed);
     static final ScopedMemoryAccess.ScopedAccessError WRONG_THREAD = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::wrongThread);
 
@@ -114,18 +112,6 @@ public abstract sealed class MemorySessionImpl
     protected MemorySessionImpl(Thread owner, ResourceList resourceList) {
         this.owner = owner;
         this.resourceList = resourceList;
-    }
-
-    public static MemorySessionImpl createConfined(Thread thread) {
-        return new ConfinedSession(thread);
-    }
-
-    public static MemorySessionImpl createShared() {
-        return new SharedSession();
-    }
-
-    public static MemorySessionImpl createImplicit(Cleaner cleaner) {
-        return new ImplicitSession(cleaner);
     }
 
     @Override
@@ -224,9 +210,6 @@ public abstract sealed class MemorySessionImpl
 
     abstract void justClose();
 
-    public static MemorySessionImpl heapSession(Object ref) {
-        return new GlobalSession(ref);
-    }
 
     /**
      * A list of all cleanup actions associated with a memory session. Cleanup actions are modelled as instances

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -76,7 +76,7 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     @Override
     ByteBuffer makeByteBuffer() {
         return NIO_ACCESS.newDirectByteBuffer(min, (int) this.length, null,
-                session == MemorySessionImpl.GLOBAL ? null : this);
+                session == SessionFactory.global() ? null : this);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/SessionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SessionFactory.java
@@ -1,0 +1,32 @@
+package jdk.internal.foreign;
+
+import java.lang.foreign.MemorySession;
+import java.lang.ref.Cleaner;
+
+public final class SessionFactory {
+
+    private SessionFactory() {
+    }
+
+    private static final MemorySession GLOBAL = new GlobalSession(null);
+
+    public static MemorySession global() {
+        return GLOBAL;
+    }
+
+    public static MemorySessionImpl createConfined(Thread thread) {
+        return new ConfinedSession(thread);
+    }
+
+    public static MemorySessionImpl createShared() {
+        return new SharedSession();
+    }
+
+    public static MemorySessionImpl createImplicit(Cleaner cleaner) {
+        return new ImplicitSession(cleaner);
+    }
+    public static MemorySessionImpl createHeap(Object ref) {
+        return new GlobalSession(ref);
+    }
+
+}


### PR DESCRIPTION
This PR proposes a break out of the various session factories from `MemorySessionImpl` to a designated class called `SessionFactory`. In the case of the previous `MemorySessionImpl.GLOBAL` this is to avoid potential circular dead-locks.