### PR TITLE
Implementation: Fix thread issues in ConfinedSession

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
@@ -25,12 +25,6 @@
 
 package jdk.internal.foreign;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.lang.ref.Cleaner;
-
-import jdk.internal.vm.annotation.ForceInline;
-
 /**
  * A confined session, which features an owner thread. The liveness check features an additional
  * confinement check - that is, calling any operation on this session from a thread other than the
@@ -39,55 +33,8 @@ import jdk.internal.vm.annotation.ForceInline;
  */
 final class ConfinedSession extends MemorySessionImpl {
 
-    private int asyncReleaseCount = 0;
-
-    static final VarHandle ASYNC_RELEASE_COUNT;
-
-    static {
-        try {
-            ASYNC_RELEASE_COUNT = MethodHandles.lookup().findVarHandle(ConfinedSession.class, "asyncReleaseCount", int.class);
-        } catch (Throwable ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
-
     public ConfinedSession(Thread owner) {
         super(owner, new ConfinedResourceList());
-    }
-
-    @Override
-    @ForceInline
-    public void acquire0() {
-        checkValidState();
-        if (state == MAX_FORKS) {
-            throw tooManyAcquires();
-        }
-        state++;
-    }
-
-    @Override
-    @ForceInline
-    public void release0() {
-        if (Thread.currentThread() == owner) {
-            state--;
-        } else {
-            // It is possible to end up here in two cases: this session was kept alive by some other confined session
-            // which is implicitly released (in which case the release call comes from the cleaner thread). Or,
-            // this session might be kept alive by a shared session, which means the release call can come from any
-            // thread.
-            ASYNC_RELEASE_COUNT.getAndAdd(this, 1);
-        }
-    }
-
-    void justClose() {
-        checkValidState();
-        int asyncCount = (int)ASYNC_RELEASE_COUNT.getVolatile(this);
-        if ((state == 0 && asyncCount == 0)
-                || ((state - asyncCount) == 0)) {
-            state = CLOSED;
-        } else {
-            throw alreadyAcquired(state - asyncCount);
-        }
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
@@ -37,6 +37,23 @@ final class ConfinedSession extends MemorySessionImpl {
         super(owner, new ConfinedResourceList());
     }
 
+    @Override
+    public void acquire0() {
+        assertIsAccessibleByCurrentThread();
+        super.acquire0();
+    }
+
+    // It is possible to that release0 is called by another thread: this session was kept alive by some other confined session
+    // which is implicitly released (in which case the release call comes from the cleaner thread). Or,
+    // this session might be kept alive by a shared session, which means the release call can come from any
+    // thread. Hence, release0() is not checked for thread usage
+
+    @Override
+    void justClose() {
+        assertIsAccessibleByCurrentThread();
+        super.justClose();
+    }
+
     /**
      * A confined resource list; no races are possible here.
      */

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -216,6 +216,12 @@ public abstract sealed class MemorySessionImpl
         }
     }
 
+    void assertIsAccessibleByCurrentThread() {
+        if (owner != null && owner != Thread.currentThread()) {
+            throw wrongThread();
+        }
+    }
+
     /**
      * Checks that this session is still alive (see {@link #isAlive()}).
      * @throws IllegalStateException if this session is already closed or if this is

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -262,7 +262,7 @@ public class TestMemorySession {
     public void testConfinedSessionWithImplicitDependency() {
         Arena root = Arena.openConfined();
         // Create many implicit sessions which depend on 'root', and let them become unreachable.
-        for (int i = 0 ; i < N_THREADS ; i++) {
+        for (int i = 0; i < N_THREADS; i++) {
             keepAlive(MemorySession.implicit(), root.session());
         }
         // Now let's keep trying to close 'root' until we succeed. This is trickier than it seems: cleanup action
@@ -274,7 +274,7 @@ public class TestMemorySession {
                 break; // success!
             } catch (IllegalStateException ex) {
                 kickGC();
-                for (int i = 0; i < N_THREADS; i++) {  // add more races from current thread
+                for (int i = 0 ; i < N_THREADS ; i++) {  // add more races from current thread
                     try (Arena arena = Arena.openConfined()) {
                         keepAlive(arena.session(), root.session());
                         // dummy
@@ -290,14 +290,14 @@ public class TestMemorySession {
         Arena root = Arena.openConfined();
         List<Thread> threads = new ArrayList<>();
         // Create many implicit sessions which depend on 'root', and let them become unreachable.
-        for (int i = 0 ; i < N_THREADS ; i++) {
+        for (int i = 0; i < N_THREADS; i++) {
             Arena arena = Arena.openShared(); // create session inside same thread!
             keepAlive(arena.session(), root.session());
             Thread t = new Thread(arena::close); // close from another thread!
             threads.add(t);
             t.start();
         }
-        for (int i = 0; i < N_THREADS; i++) { // add more races from current thread
+        for (int i = 0 ; i < N_THREADS ; i++) { // add more races from current thread
             try (Arena arena = Arena.openConfined()) {
                 keepAlive(arena.session(), root.session());
                 // dummy

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -202,6 +202,14 @@ public class TestMemorySession {
     }
 
     @Test
+    public void testCloseConfinedLockInSameThread() {
+        Arena arena = Arena.openConfined();
+        Arena handle = Arena.openConfined();
+        keepAlive(handle.session(), arena.session());
+        handle.close();
+    }
+
+    @Test
     public void testCloseConfinedLock() {
         Arena arena = Arena.openConfined();
         Arena handle = Arena.openConfined();

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -57,7 +57,7 @@ public class TestMemorySession {
     public void testConfined() {
         AtomicInteger acc = new AtomicInteger();
         Arena arena = Arena.openConfined();
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             addCloseAction(arena.session(), () -> acc.addAndGet(delta));
         }
@@ -71,7 +71,7 @@ public class TestMemorySession {
     public void testSharedSingleThread(SessionSupplier sessionSupplier) {
         AtomicInteger acc = new AtomicInteger();
         MemorySession session = sessionSupplier.get();
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             addCloseAction(session, () -> acc.addAndGet(delta));
         }
@@ -95,7 +95,7 @@ public class TestMemorySession {
         List<Thread> threads = new ArrayList<>();
         MemorySession session = sessionSupplier.get();
         AtomicReference<MemorySession> sessionRef = new AtomicReference<>(session);
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             Thread thread = new Thread(() -> {
                 try {
@@ -149,7 +149,7 @@ public class TestMemorySession {
     public void testLockSingleThread() {
         Arena arena = Arena.openConfined();
         List<Arena> handles = new ArrayList<>();
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             Arena handle = Arena.openConfined();
             keepAlive(handle.session(), arena.session());
             handles.add(handle);
@@ -172,7 +172,7 @@ public class TestMemorySession {
     public void testLockSharedMultiThread() {
         Arena arena = Arena.openShared();
         AtomicInteger lockCount = new AtomicInteger();
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             new Thread(() -> {
                 try (Arena handle = Arena.openConfined()) {
                     keepAlive(handle.session(), arena.session());
@@ -262,7 +262,7 @@ public class TestMemorySession {
     public void testConfinedSessionWithImplicitDependency() {
         Arena root = Arena.openConfined();
         // Create many implicit sessions which depend on 'root', and let them become unreachable.
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             keepAlive(MemorySession.implicit(), root.session());
         }
         // Now let's keep trying to close 'root' until we succeed. This is trickier than it seems: cleanup action
@@ -290,7 +290,7 @@ public class TestMemorySession {
         Arena root = Arena.openConfined();
         List<Thread> threads = new ArrayList<>();
         // Create many implicit sessions which depend on 'root', and let them become unreachable.
-        for (int i = 0; i < N_THREADS; i++) {
+        for (int i = 0 ; i < N_THREADS ; i++) {
             Arena arena = Arena.openShared(); // create session inside same thread!
             keepAlive(arena.session(), root.session());
             Thread t = new Thread(arena::close); // close from another thread!
@@ -358,7 +358,7 @@ public class TestMemorySession {
     }
 
     private void kickGC() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0 ; i < 100 ; i++) {
             byte[] b = new byte[100];
             System.gc();
             Thread.onSpinWait();
@@ -367,9 +367,9 @@ public class TestMemorySession {
 
     @DataProvider
     static Object[][] drops() {
-        return new Object[][]{
-                {(Supplier<Arena>) Arena::openConfined},
-                {(Supplier<Arena>) Arena::openShared},
+        return new Object[][] {
+                { (Supplier<Arena>) Arena::openConfined},
+                { (Supplier<Arena>) Arena::openShared},
         };
     }
 
@@ -387,11 +387,11 @@ public class TestMemorySession {
     interface SessionSupplier extends Supplier<MemorySession> {
 
         static void close(MemorySession session) {
-            ((MemorySessionImpl) session).close();
+            ((MemorySessionImpl)session).close();
         }
 
         static boolean isImplicit(MemorySession session) {
-            return !((MemorySessionImpl) session).isCloseable();
+            return !((MemorySessionImpl)session).isCloseable();
         }
 
         static SessionSupplier ofImplicit() {
@@ -405,18 +405,18 @@ public class TestMemorySession {
 
     @DataProvider(name = "sharedSessions")
     static Object[][] sharedSessions() {
-        return new Object[][]{
-                {SessionSupplier.ofArena(Arena::openShared)},
-                {SessionSupplier.ofImplicit()},
+        return new Object[][] {
+                { SessionSupplier.ofArena(Arena::openShared) },
+                { SessionSupplier.ofImplicit() },
         };
     }
 
     @DataProvider(name = "allSessions")
     static Object[][] allSessions() {
-        return new Object[][]{
-                {SessionSupplier.ofArena(Arena::openConfined)},
-                {SessionSupplier.ofArena(Arena::openShared)},
-                {SessionSupplier.ofImplicit()},
+        return new Object[][] {
+                { SessionSupplier.ofArena(Arena::openConfined) },
+                { SessionSupplier.ofArena(Arena::openShared) },
+                { SessionSupplier.ofImplicit() },
         };
     }
 }


### PR DESCRIPTION
This PR proposes changes, mainly to ConfinedSession, so that the contract of `isClosed()` can be fulfilled across several threads. This means resource counting must be done concurrently and not as before with normal memory semantics.